### PR TITLE
Use input video FPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A brief description of CLI args:
 
 `--output_video_path` use this argument to provide absolute path where we want to store the blurred video. You MUST provide `--output_video_path` with `--input_video_path` otherwise code will throw `ValueError`.
 
-`--output_video_fps` use this argument to provide FPS for the output video. The values must be positive integers, if not provided this defaults to 30.
+`--output_video_fps` use this argument to provide FPS for the output video. The values must be positive integers. If not provided, the FPS from the input video is used.
 
 
 
@@ -93,7 +93,7 @@ python script/demo_ego_blur.py --lp_model_path /home/${USER}/ego_blur_assets/ego
 
 #### demo command for face blurring and license plate blurring on an input image and video
 ```
-python script/demo_ego_blur.py --face_model_path /home/${USER}/ego_blur_assets/ego_blur_face.jit --lp_model_path /home/${USER}/ego_blur_assets/ego_blur_lp.jit --input_image_path /home/${USER}/ego_blur_assets/test_image.jpg --output_image_path /home/${USER}/ego_blur_assets/test_image_output.jpg  --input_video_path /home/${USER}/ego_blur_assets/test_video.mp4 --output_video_path /home/${USER}/ego_blur_assets/test_video_output.mp4 --face_model_score_threshold 0.9 --lp_model_score_threshold 0.9 --nms_iou_threshold 0.3 --scale_factor_detections 1 --output_video_fps 20
+python script/demo_ego_blur.py --face_model_path /home/${USER}/ego_blur_assets/ego_blur_face.jit --lp_model_path /home/${USER}/ego_blur_assets/ego_blur_lp.jit --input_image_path /home/${USER}/ego_blur_assets/test_image.jpg --output_image_path /home/${USER}/ego_blur_assets/test_image_output.jpg  --input_video_path /home/${USER}/ego_blur_assets/test_video.mp4 --output_video_path /home/${USER}/ego_blur_assets/test_video_output.mp4 --face_model_score_threshold 0.9 --lp_model_score_threshold 0.9 --nms_iou_threshold 0.3 --scale_factor_detections 1 --output_video_fps 20  # output_video_fps is optional
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- make output FPS optional and default to the input video's FPS
- document new FPS behaviour in README

## Testing
- `python -m py_compile script/demo_ego_blur.py`
- `python script/demo_ego_blur.py --help` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_684fb22acca48320a9ef444dbec50847