### PR TITLE
Use input video FPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ A brief description of CLI args:
 
 `--input_video_path` use this argument to provide absolute path for the given video on which we want to make detections and perform blurring. You MUST provide either `--input_image_path` or `--input_video_path` or both. If none is provided code will throw a `ValueError`.
 
-`--output_video_path` use this argument to provide absolute path where we want to store the blurred video. You MUST provide `--output_video_path` with `--input_video_path` otherwise code will throw `ValueError`.
+`--output_video_path` use this argument to provide absolute path where we want to store the blurred video. If not supplied, the output is written under an `output` folder using the input video's name with `_output` appended.
 
-`--output_video_fps` use this argument to provide FPS for the output video. The values must be positive integers, if not provided this defaults to 30.
+`--output_video_fps` use this argument to provide FPS for the output video. The values must be positive integers. If not provided, the FPS from the input video is used.
+
+When processing a video, the script shows a progress bar in the console and reports the total processing time and how it compares to the video length.
 
 
 
@@ -93,7 +95,7 @@ python script/demo_ego_blur.py --lp_model_path /home/${USER}/ego_blur_assets/ego
 
 #### demo command for face blurring and license plate blurring on an input image and video
 ```
-python script/demo_ego_blur.py --face_model_path /home/${USER}/ego_blur_assets/ego_blur_face.jit --lp_model_path /home/${USER}/ego_blur_assets/ego_blur_lp.jit --input_image_path /home/${USER}/ego_blur_assets/test_image.jpg --output_image_path /home/${USER}/ego_blur_assets/test_image_output.jpg  --input_video_path /home/${USER}/ego_blur_assets/test_video.mp4 --output_video_path /home/${USER}/ego_blur_assets/test_video_output.mp4 --face_model_score_threshold 0.9 --lp_model_score_threshold 0.9 --nms_iou_threshold 0.3 --scale_factor_detections 1 --output_video_fps 20
+python script/demo_ego_blur.py --face_model_path /home/${USER}/ego_blur_assets/ego_blur_face.jit --lp_model_path /home/${USER}/ego_blur_assets/ego_blur_lp.jit --input_image_path /home/${USER}/ego_blur_assets/test_image.jpg --output_image_path /home/${USER}/ego_blur_assets/test_image_output.jpg  --input_video_path /home/${USER}/ego_blur_assets/test_video.mp4 --face_model_score_threshold 0.9 --lp_model_score_threshold 0.9 --nms_iou_threshold 0.3 --scale_factor_detections 1 --output_video_fps 20  # output_video_path is optional
 ```
 
 ## License

--- a/script/demo_ego_blur.py
+++ b/script/demo_ego_blur.py
@@ -8,6 +8,17 @@ import argparse
 import os
 from functools import lru_cache
 from typing import List
+import time
+
+
+def print_progress(iteration: int, total: int, prefix: str = "", length: int = 30) -> None:
+    """Simple progress bar."""
+    percent = 100 * (iteration / float(total))
+    filled_length = int(length * iteration // total)
+    bar = "█" * filled_length + "-" * (length - filled_length)
+    print(f"\r{prefix} |{bar}| {percent:.1f}%", end="")
+    if iteration >= total:
+        print()
 
 import cv2
 import numpy as np
@@ -96,15 +107,21 @@ def parse_args():
         required=False,
         type=str,
         default=None,
-        help="Absolute path where we want to store the visualized video",
+        help=(
+            "Absolute path where we want to store the visualized video. If not "
+            "provided, it will be created under the output folder using the "
+            "input video name."
+        ),
     )
 
     parser.add_argument(
         "--output_video_fps",
         required=False,
         type=int,
-        default=30,
-        help="FPS for the output video",
+        default=None,
+        help=(
+            "FPS for the output video. If not provided, the input video's FPS is used"
+        ),
     )
 
     return parser.parse_args()
@@ -145,12 +162,14 @@ def validate_inputs(args: argparse.Namespace) -> argparse.Namespace:
         raise ValueError(
             f"Invalid scale_factor_detections {args.scale_factor_detections}"
         )
-    if not 1 <= args.output_video_fps or not (
-        isinstance(args.output_video_fps, int) and args.output_video_fps % 1 == 0
-    ):
-        raise ValueError(
-            f"Invalid output_video_fps {args.output_video_fps}, should be a positive integer"
-        )
+    if args.output_video_fps is not None:
+        if not 1 <= args.output_video_fps or not (
+            isinstance(args.output_video_fps, int)
+            and args.output_video_fps % 1 == 0
+        ):
+            raise ValueError(
+                f"Invalid output_video_fps {args.output_video_fps}, should be a positive integer"
+            )
 
     # input/output paths checks
     if args.face_model_path is None and args.lp_model_path is None:
@@ -163,10 +182,13 @@ def validate_inputs(args: argparse.Namespace) -> argparse.Namespace:
         raise ValueError(
             "Please provide output_image_path for the visualized image to save."
         )
-    if args.input_video_path is not None and args.output_video_path is None:
-        raise ValueError(
-            "Please provide output_video_path for the visualized video to save."
-        )
+    if args.input_video_path is not None:
+        if args.output_video_path is None:
+            base_name, ext = os.path.splitext(os.path.basename(args.input_video_path))
+            output_dir = os.path.join(os.getcwd(), "output")
+            args.output_video_path = os.path.join(output_dir, base_name + "_output" + ext)
+        if not os.path.exists(os.path.dirname(args.output_video_path)):
+            create_output_directory(args.output_video_path)
     if args.input_image_path is not None and not os.path.exists(args.input_image_path):
         raise ValueError(f"{args.input_image_path} does not exist.")
     if args.input_video_path is not None and not os.path.exists(args.input_video_path):
@@ -179,10 +201,6 @@ def validate_inputs(args: argparse.Namespace) -> argparse.Namespace:
         os.path.dirname(args.output_image_path)
     ):
         create_output_directory(args.output_image_path)
-    if args.output_video_path is not None and not os.path.exists(
-        os.path.dirname(args.output_video_path)
-    ):
-        create_output_directory(args.output_video_path)
 
     # check we have write permissions on output paths
     if args.output_image_path is not None and not os.access(
@@ -407,7 +425,7 @@ def visualize_video(
     output_video_path: str,
     scale_factor_detections: float,
     output_video_fps: int,
-):
+): 
     """
     parameter input_video_path: absolute path to the input video
     parameter face_detector: face detector model to perform face detections
@@ -423,7 +441,16 @@ def visualize_video(
     """
     visualized_images = []
     video_reader_clip = VideoFileClip(input_video_path)
-    for frame in video_reader_clip.iter_frames():
+    fps = (
+        output_video_fps
+        if output_video_fps is not None
+        else int(round(video_reader_clip.fps))
+    )
+    total_frames = int(video_reader_clip.fps * video_reader_clip.duration)
+    video_duration = video_reader_clip.duration
+    start_time = time.time()
+    for idx, frame in enumerate(video_reader_clip.iter_frames()):
+        print_progress(idx + 1, total_frames, prefix="Processing")
         if len(frame.shape) == 2:
             frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2RGB)
         image = frame.copy()
@@ -460,11 +487,17 @@ def visualize_video(
         )
 
     video_reader_clip.close()
+    elapsed_time = time.time() - start_time
+    ratio = elapsed_time / video_duration if video_duration else 0
 
     if visualized_images:
-        video_writer_clip = ImageSequenceClip(visualized_images, fps=output_video_fps)
+        video_writer_clip = ImageSequenceClip(visualized_images, fps=fps)
         video_writer_clip.write_videofile(output_video_path)
         video_writer_clip.close()
+    print(
+        f"Video processing completed in {elapsed_time:.2f} seconds. "
+        f"({ratio:.2f}x realtime)"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make output FPS optional and default to the input video's FPS
- show progress while processing video frames and report elapsed time relative to video length
- default output video path now derived from input video name in an `output` folder
- document new default path, progress information, and processing ratio

## Testing
- `python -m py_compile script/demo_ego_blur.py`
- `python script/demo_ego_blur.py --help` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_684fb22acca48320a9ef444dbec50847