### PR TITLE
Add audio support to video output

### DIFF
--- a/script/demo_ego_blur.py
+++ b/script/demo_ego_blur.py
@@ -566,6 +566,20 @@ def visualize_video(
 
     video_reader_clip.close()
     video_writer.release()
+    # attach original audio to the processed video
+    try:
+        audio_clip = VideoFileClip(input_video_path).audio
+        if audio_clip is not None:
+            temp_output = output_video_path + ".temp.mp4"
+            (
+                VideoFileClip(output_video_path)
+                .set_audio(audio_clip)
+                .write_videofile(temp_output, fps=fps)
+            )
+            os.replace(temp_output, output_video_path)
+            audio_clip.close()
+    except Exception as e:  # pragma: no cover - best effort audio handling
+        print(f"Failed to add audio: {e}")
     elapsed_time = time.time() - start_time
     ratio = elapsed_time / video_duration if video_duration else 0
 

--- a/script/video_multiprocessing.py
+++ b/script/video_multiprocessing.py
@@ -291,8 +291,12 @@ def process_video_multiprocessing(
     output_fps = output_video_fps if output_video_fps is not None else fps
     clips = [VideoFileClip(p) for p in part_paths]
     final_clip = concatenate_videoclips(clips)
+    input_clip = VideoFileClip(input_video_path)
+    if input_clip.audio is not None:
+        final_clip = final_clip.set_audio(input_clip.audio)
     final_clip.write_videofile(output_video_path, fps=output_fps)
     final_clip.close()
+    input_clip.close()
     for clip in clips:
         clip.close()
         os.remove(clip.filename)


### PR DESCRIPTION
## Summary
- ensure generated videos preserve original audio
- attach audio track in demo and multiprocessing scripts

## Testing
- `python -m py_compile script/demo_ego_blur.py script/video_multiprocessing.py`

------
https://chatgpt.com/codex/tasks/task_b_685d0245cbd08320b47345399b36b394